### PR TITLE
Fix: Add compressed flag to curl command to decompress downloaded file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# report-proxy-fi
-
-
+# PayNet Financial Report Script
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Below is a concise guide on how to use the provided Bash (`.sh`) and Batch (`.ba
 - `--window` – (Optional) Additional windowing parameter for the report
 - `--output-dir` – (Optional) Directory to save downloaded files; defaults to current directory if missing
 - `--api-url` – (Optional) Report service API URL; defaults to https://api.reports.paynet.my
-- `--compressed` - Decompress the downloaded file (optional)
 - `--help` – Display the script’s built-in usage message
 
 ### Bash Script (Linux/macOS)
@@ -51,7 +50,6 @@ Example
   --date 2024-06-10 \
   --product MYDEBIT \
   --fiid FIID \
-  --compressed \
   --api-url https://api.reports.uat.inet.paynet.my \
   --output-dir ./downloads
 ```
@@ -82,7 +80,6 @@ download_report.bat ^
   --date 2024-11-08 ^
   --product MYDEBIT ^
   --fiid FIID ^
-  --compressed
   --api-url https://api.reports.uat.inet.paynet.my
 ```
 **🔧 Command Not Found Errors**
@@ -97,14 +94,9 @@ download_report.bat ^
 - **Empty/missing file**: The one-time download URL may have expired - retry with fresh credentials
 - **OTT Invalid**: One-time token has been used or expired - generate a new download request
 
-**📄 File Format Problems**
-- **Unreadable file format**: Add the `--compressed` flag to handle gzipped responses
-- **Corrupted download**: Check network connection and retry the download
-
 ### Best Practices
 
-- Store credentials securely and avoid hardcoding them in scripts
-- Use the `--compressed` flag for automatic decompression
+- Store credentials securely and NEVER hardcoding them in scripts
 
 ### Additional Resources
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a public facing API running on a Lambda function of OSP's report API
 
 Below is a concise guide on how to use the provided Bash (`.sh`) and Batch (`.bat`) scripts for downloading reports.
 
-## Script flags
+## Script **flags**
 
 **Options**
 
@@ -23,6 +23,7 @@ Below is a concise guide on how to use the provided Bash (`.sh`) and Batch (`.ba
 - `--window` – (Optional) Additional windowing parameter for the report
 - `--output-dir` – (Optional) Directory to save downloaded files; defaults to current directory if missing
 - `--api-url` – (Optional) Report service API URL; defaults to https://api.reports.paynet.my
+- `--compressed` - Decompress the downloaded file (optional)
 - `--help` – Display the script’s built-in usage message
 
 ### Bash Script (Linux/macOS)
@@ -52,6 +53,7 @@ Example
   --date 2024-06-10 \
   --product MYDEBIT \
   --fiid FIID \
+  --compressed \
   --api-url https://api.reports.uat.inet.paynet.my \
   --output-dir ./downloads
 ```
@@ -82,28 +84,31 @@ download_report.bat ^
   --date 2024-11-08 ^
   --product MYDEBIT ^
   --fiid FIID ^
+  --compressed
   --api-url https://api.reports.uat.inet.paynet.my
 ```
+**🔧 Command Not Found Errors**
+- **OpenSSL/curl missing**: Install required tools or add them to your system PATH
+- **Permission denied (Linux/macOS)**: Run `chmod +x download_report.sh` to make the script executable
 
-### Troubleshooting
+**🔐 Authentication Problems**
+- **Invalid token**: Verify your client credentials are correct
+- **Authentication failed**: Check HMAC signature generation and timestamp
 
-1. **OpenSSL or curl not found**
+**📁 Download Issues**
+- **Empty/missing file**: The one-time download URL may have expired - retry with fresh credentials
+- **OTT Invalid**: One-time token has been used or expired - generate a new download request
 
-   - Install them or add to your system PATH.
+**📄 File Format Problems**
+- **Unreadable file format**: Add the `--compressed` flag to handle gzipped responses
+- **Corrupted download**: Check network connection and retry the download
 
-2. **Permission denied (Linux/macOS)**
+### Best Practices
 
-   - Ensure the script is executable: chmod +x download_report.sh.
+- Store credentials securely and avoid hardcoding them in scripts
+- Use the `--compressed` flag for automatic decompression
 
-3. **Invalid token / authentication failed**
-
-   - Double-check your client credentials or HMAC signature logic.
-
-4. **Empty/missing file/OTT Invalid**
-   
-   - The one-time URL may have expired or been used already. Retry obtaining the URL with fresh credentials.
-
-### Troubleshooting
+### Additional Resources
 
 For more information , please visit the following online resource available on PayNet's Developer's Portal 
 

--- a/download_report.bat
+++ b/download_report.bat
@@ -6,6 +6,7 @@ REM Default values
 REM ============================================================
 set "API_URL=https://api.reports.paynet.my"
 set "OUTPUT_DIR=.\"
+set "COMPRESSED=false"
 
 REM ============================================================
 REM Parse command line arguments
@@ -175,6 +176,11 @@ if "%~1"=="--api-url" (
   shift /1
   goto parse_args
 )
+if "%~1"=="--compressed" (
+  set "COMPRESSED=true"
+  shift /1
+  goto parse_args
+)
 if "%~1"=="--help" (
     call :usage
     exit /b 0
@@ -253,6 +259,7 @@ echo  - Report Type: %REPORT_TYPE%
 echo  - Product: %PRODUCT%
 echo  - Date: %DDATE%
 echo  - Output Directory: %OUTPUT_DIR%
+echo  - Compressed: %COMPRESSED%
 
 REM ============================================================
 REM Get OAuth token
@@ -348,9 +355,13 @@ set "BODY_FILE=%TEMP%\body_%RANDOM%.bin"
 echo Making a single request to avoid invalidating the URL...
 
 REM Perform a single request, writing headers and body to separate temp files
-curl -sSL -D "%HEADERS_FILE%" -o "%BODY_FILE%" ^
-    "%NEW_URL%"
-
+if "%COMPRESSED%"=="true" (
+    curl -sSL --compressed -D "%HEADERS_FILE%" -o "%BODY_FILE%" ^
+        "%NEW_URL%"
+) else (
+    curl -sSL -D "%HEADERS_FILE%" -o "%BODY_FILE%" ^
+        "%NEW_URL%"
+)
 REM Extract Content-Disposition header if present
 set "CONTENT_DISPOSITION="
 for /f "tokens=* usebackq" %%h in (`findstr /i "Content-Disposition" "%HEADERS_FILE%"`) do (
@@ -439,10 +450,11 @@ echo   --date                Date for the report in YYYY-MM-DD format (required)
 echo   --product             Product type (required)
 echo   --output-dir          Directory to save downloaded files (optional)
 echo   --api-url             API URL (optional)
+echo   --compressed          Decompress the downloaded file (optional)
 echo   --help                Display this help message
 echo.
 echo Example:
-echo   %~nx0 --client-id myclient --client-secret mysecret --fiid MBB --report SETL01 --date 2024-11-08 --product mydebit
+echo   %~nx0 --client-id myclient --client-secret mysecret --fiid MBB --report SETL01 --date 2024-11-08 --product mydebit --compressed
 echo   %~nx0 --client-id myclient --client-secret mysecret --fiid CIMB --report DFCUP --date 2024-11-08 --product san
 echo   %~nx0 --client-id myclient --client-secret mysecret --fiid RHB --report SETL01_C1 --date 2024-11-08 --product mydebit --output-dir .\downloads
 goto :eof

--- a/download_report.bat
+++ b/download_report.bat
@@ -6,7 +6,6 @@ REM Default values
 REM ============================================================
 set "API_URL=https://api.reports.paynet.my"
 set "OUTPUT_DIR=.\"
-set "COMPRESSED=false"
 
 REM ============================================================
 REM Parse command line arguments
@@ -176,11 +175,6 @@ if "%~1"=="--api-url" (
   shift /1
   goto parse_args
 )
-if "%~1"=="--compressed" (
-  set "COMPRESSED=true"
-  shift /1
-  goto parse_args
-)
 if "%~1"=="--help" (
     call :usage
     exit /b 0
@@ -259,7 +253,6 @@ echo  - Report Type: %REPORT_TYPE%
 echo  - Product: %PRODUCT%
 echo  - Date: %DDATE%
 echo  - Output Directory: %OUTPUT_DIR%
-echo  - Compressed: %COMPRESSED%
 
 REM ============================================================
 REM Get OAuth token
@@ -355,13 +348,8 @@ set "BODY_FILE=%TEMP%\body_%RANDOM%.bin"
 echo Making a single request to avoid invalidating the URL...
 
 REM Perform a single request, writing headers and body to separate temp files
-if "%COMPRESSED%"=="true" (
-    curl -sSL --compressed -D "%HEADERS_FILE%" -o "%BODY_FILE%" ^
-        "%NEW_URL%"
-) else (
-    curl -sSL -D "%HEADERS_FILE%" -o "%BODY_FILE%" ^
-        "%NEW_URL%"
-)
+curl -sSL --compressed -D "%HEADERS_FILE%" -o "%BODY_FILE%" ^
+    "%NEW_URL%"
 REM Extract Content-Disposition header if present
 set "CONTENT_DISPOSITION="
 for /f "tokens=* usebackq" %%h in (`findstr /i "Content-Disposition" "%HEADERS_FILE%"`) do (
@@ -450,11 +438,10 @@ echo   --date                Date for the report in YYYY-MM-DD format (required)
 echo   --product             Product type (required)
 echo   --output-dir          Directory to save downloaded files (optional)
 echo   --api-url             API URL (optional)
-echo   --compressed          Decompress the downloaded file (optional)
 echo   --help                Display this help message
 echo.
 echo Example:
-echo   %~nx0 --client-id myclient --client-secret mysecret --fiid MBB --report SETL01 --date 2024-11-08 --product mydebit --compressed
+echo   %~nx0 --client-id myclient --client-secret mysecret --fiid MBB --report SETL01 --date 2024-11-08 --product mydebit
 echo   %~nx0 --client-id myclient --client-secret mysecret --fiid CIMB --report DFCUP --date 2024-11-08 --product san
 echo   %~nx0 --client-id myclient --client-secret mysecret --fiid RHB --report SETL01_C1 --date 2024-11-08 --product mydebit --output-dir .\downloads
 goto :eof

--- a/download_report.sh
+++ b/download_report.sh
@@ -13,11 +13,10 @@ usage() {
     echo "  --date                Date for the report in YYYY-MM-DD format (required)"
     echo "  --output-dir          Directory to save downloaded files (optional)"
     echo "  --api-url             API URL (optional)"
-    echo "  --compressed          Decompress the downloaded file (optional)"
     echo "  --help                Display this help message"
     echo
     echo "Example:"
-    echo "  $0 --client-id myclient --client-secret mysecret --product mydebit --report SETL01 --date 2024-11-08 --compressed"
+    echo "  $0 --client-id myclient --client-secret mysecret --product mydebit --report SETL01 --date 2024-11-08"
     echo "  $0 --client-id myclient --client-secret mysecret --product san --report DFCUP --date 2024-11-08"
     echo "  $0 --client-id myclient --client-secret mysecret --product mydebit --report SETL01_C1 --date 2024-11-08 --output-dir ./downloads"
     exit 1
@@ -135,10 +134,6 @@ while [[ $# -gt 0 ]]; do
             fi
             OUTPUT_DIR="$2"
             shift 2
-            ;;
-        --compressed)
-            COMPRESSED=true
-            shift
             ;;
         --help)
             usage
@@ -268,12 +263,7 @@ echo "Downloading file..."
 # Create a temporary file for headers
 HEADERS_FILE=$(mktemp)
 
-# Build curl command with opt --compressed flag if specified
-CURL_CMD="curl -s -w \"%{http_code}\" -D \"${HEADERS_FILE}\" -o \"${OUTPUT_DIR}temp_download\""
-
-if [ "$COMPRESSED" = true ]; then
-    CURL_CMD="$CURL_CMD --compressed"
-fi
+CURL_CMD="curl --compressed -s -w \"%{http_code}\" -D \"${HEADERS_FILE}\" -o \"${OUTPUT_DIR}temp_download\""
 
 CURL_CMD="$CURL_CMD \"$NEW_URL\""
 # Download the file in a single request while capturing headers


### PR DESCRIPTION
This PR adds support for the --compressed flag to enable automatic decompression during file downloads via curl, resolving the issue with unreadable content.